### PR TITLE
Uses codecov/codecov@1.0.5

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 version: 2.1
 orbs:
-  codecov: codecov/codecov@1.0.4
+  codecov: codecov/codecov@1.0.5
 jobs:
   build:
     docker:


### PR DESCRIPTION
1.0.5 is the latest.
https://circleci.com/orbs/registry/orb/codecov/codecov